### PR TITLE
No Merge Require - support prompt in authorize

### DIFF
--- a/packages/openauth/src/issuer.ts
+++ b/packages/openauth/src/issuer.ts
@@ -172,6 +172,7 @@ export interface AuthorizationState {
   state: string
   client_id: string
   audience?: string
+  prompts?: string
   pkce?: {
     challenge: string
     method: "S256"
@@ -1018,12 +1019,14 @@ export function issuer<
     const audience = c.req.query("audience")
     const code_challenge = c.req.query("code_challenge")
     const code_challenge_method = c.req.query("code_challenge_method")
+    const prompt = c.req.query("prompt")
     const authorization: AuthorizationState = {
       response_type,
       redirect_uri,
       state,
       client_id,
       audience,
+      prompt,
       pkce:
         code_challenge && code_challenge_method
           ? {
@@ -1062,7 +1065,11 @@ export function issuer<
     )
       throw new UnauthorizedClientError(client_id, redirect_uri)
     await auth.set(c, "authorization", 60 * 60 * 24, authorization)
-    if (provider) return c.redirect(`/${provider}/authorize`)
+    if (provider) {
+      const providerUrl = new URL(`/${provider}/authorize`, c.req.url)
+      if (prompt) providerUrl.searchParams.set("prompt", prompt)
+      return c.redirect(providerUrl.pathname + providerUrl.search)
+    }
     const providers = Object.keys(input.providers)
     if (providers.length === 1) return c.redirect(`/${providers[0]}/authorize`)
     return auth.forward(

--- a/packages/openauth/src/provider/oauth2.ts
+++ b/packages/openauth/src/provider/oauth2.ts
@@ -242,6 +242,10 @@ export function Oauth2Provider(
         for (const [key, value] of Object.entries(query)) {
           authorization.searchParams.set(key, value)
         }
+        const prompt = c.req.query("prompt")
+        if (prompt) {
+          authorization.searchParams.set("prompt", prompt)
+        }
         return c.redirect(authorization.toString())
       })
 

--- a/packages/openauth/src/ui/password.tsx
+++ b/packages/openauth/src/ui/password.tsx
@@ -140,8 +140,10 @@ type PasswordUICopy = typeof DEFAULT_COPY
 /**
  * Configure the password UI.
  */
-export interface PasswordUIOptions
-  extends Pick<PasswordConfig, "sendCode" | "validatePassword"> {
+export interface PasswordUIOptions extends Pick<
+  PasswordConfig,
+  "sendCode" | "validatePassword"
+> {
   /**
    * Custom copy for the UI.
    */


### PR DESCRIPTION
There is not prompt field in the `AuthorizationState` by allowing this we are able to do the following.

The openauth package doesn't forward the prompt parameter from our app to GitHub. So when we tell it "hey, ask the user for consent again," it just ignores us and does a normal login.                                                                     
                                                                                                                                  
  We need two small plumbing changes inside openauth to pass prompt through:                                                      
                                                                                                                                  
  1. issuer.ts — when our app sends /authorize?prompt=consent, the issuer needs to read it and forward it to the provider's
  internal /github/authorize?prompt=consent route
  2. oauth2.ts — the provider needs to read it and put it on the actual GitHub URL:
  https://github.com/login/oauth/authorize?...&prompt=consent

  Without both, the prompt=consent gets dropped along the way and GitHub never sees it.

This PR will solve this. There was PR in portal related to this: https://github.com/DefangLabs/portal/pull/484.

There no need to merge this PR unless we want to sync the Git subtree.